### PR TITLE
Do not copy all files other than wrl extension

### DIFF
--- a/generate_robot_description.sh
+++ b/generate_robot_description.sh
@@ -34,9 +34,9 @@ mkdir -p ${gen_path}/vrml
 
 # Copy generated vrml files
 echo "-- Copying vrml model files from ${robot_dir}/model to ${gen_path}/vrml"
-rsync -av --prune-empty-dirs --include '*.wrl' --exclude '*.*' ${robot_dir}/model/ ${gen_path}/vrml
+rsync -av --prune-empty-dirs --include '*.wrl' --exclude '*' ${robot_dir}/model/ ${gen_path}/vrml
 echo "-- Copying generated vrml model files from ${build_dir}/model to ${gen_path}/vrml"
-rsync -av --prune-empty-dirs --include '*.wrl' --exclude '*.*' ${build_dir}/model/ ${gen_path}/vrml
+rsync -av --prune-empty-dirs --include '*.wrl' --exclude '*' ${build_dir}/model/ ${gen_path}/vrml
 
 # generate robot model (VRML, collada, urdf and dae meshes)
 function generate_urdf()

--- a/generate_robot_description.sh
+++ b/generate_robot_description.sh
@@ -95,9 +95,9 @@ function replace_template_variables()
 {
   echo "-- Replacing variables in $1"
   sed -i -e"s#@ROBOT_NAME@#${robot_name}#g" $1
-  sed -i -e"s#@ROBOT_DESCRIPTION_NAME@#${robot_desc_name}#g" $1 
+  sed -i -e"s#@ROBOT_DESCRIPTION_NAME@#${robot_desc_name}#g" $1
   sed -i -e"s#@ROBOT_DESCRIPTION_DESCRIPTION@#${description}#g" $1
-  sed -i -e"s#@ROBOT_DESCRIPTION_VERSION@#${version}#g" $1 
+  sed -i -e"s#@ROBOT_DESCRIPTION_VERSION@#${version}#g" $1
   sed -i -e"s#@ROBOT_DESCRIPTION_MAINTAINER_NAME@#${maintainter_name}#g" $1
   sed -i -e"s#@ROBOT_DESCRIPTION_MAINTAINER_EMAIL@#${maintainter_email}#g" $1
   sed -i -e"s#@ROBOT_REPOSITORY@#${robot_repository}#g" $1


### PR DESCRIPTION
It ’s a really small thing, but are there special reasons that `'*.*'` is passed to `--exclude` instead of just `'*'`?
https://github.com/arntanguy/generate_robot_description/blob/8bb315cfec0fd2dc628a8f81233549f4b317dcfa/generate_robot_description.sh#L39

`Makefile` in `build/model` is copied in the current code, which probably be not intended.
I confirmed the generated robot_description works after this PR's patch.