### PR TITLE
Add mimic joints

### DIFF
--- a/generate_robot_description.sh
+++ b/generate_robot_description.sh
@@ -49,6 +49,12 @@ function generate_urdf()
   exit_if_error "Failed to convert VRML model to collada ($vrml_model})"
   rosrun collada_urdf collada_to_urdf ${gen_collada_path} --output_file ${gen_urdf_path} --mesh_output_dir ${gen_path}/meshes/${vrml_model_name} --mesh_prefix "${urdf_mesh_prefix}/meshes/${vrml_model_name}" ${collada_urdf_options}
   exit_if_error "Failed to convert collada to urdf (${gen_collada_path})"
+  mimic_path=${robot_dir}/mimic/${vrml_model_name}.yaml
+  if [ -f $mimic_path ]
+  then
+    ./scripts/add_mimic.py ${gen_urdf_path} ${mimic_path}
+    exit_if_error "Failed to add mimic joints to urdf (${mimic_path})"
+  fi
 }
 
 function generate_convexes()

--- a/scripts/add_mimic.py
+++ b/scripts/add_mimic.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import sys
+import yaml
+import re
+
+
+if __name__ == "__main__":
+    # Check arguments
+    if len(sys.argv) < 3:
+        print("usage: {} [urdf_path] [mimic_path]".format(sys.argv[0]))
+        exit(1)
+
+    # Load a urdf file
+    urdf_path = sys.argv[1]
+    with open(urdf_path) as urdf_file:
+        urdf_lines = urdf_file.readlines()
+
+    # Load a mimic information file
+    mimic_path = sys.argv[2]
+    with open(mimic_path) as mimic_file:
+        mimic_info_list = yaml.safe_load(mimic_file)
+
+    # Add lines for mimic joints
+    i = 0
+    while i < len(urdf_lines):
+        for mimic_info in mimic_info_list:
+            # If the current line corresponds to mimic target joint
+            if re.match("\s+<joint\s+name=\"{}\"\s+type=.*?>s*\n".format(mimic_info["trg_joint"]), urdf_lines[i]):
+                # Add a line for the mimic joint specification below the current line
+                mimic_line = "    <mimic joint=\"{}\"".format(mimic_info["src_joint"])
+                for mimic_prop in mimic_info["properties"]:
+                    mimic_line += " {}=\"{}\"".format(mimic_prop, mimic_info["properties"][mimic_prop])
+                mimic_line += " />\n"
+                urdf_lines.insert(i+1, mimic_line)
+                i += 1 # Skip a newly added line
+                break
+        i += 1
+
+    # Save a urdf file with mimic joint specifications
+    with open(urdf_path, mode="w") as urdf_file_out:
+        urdf_file_out.writelines(urdf_lines)


### PR DESCRIPTION
I checked the urdf model with mimic joints are generated and worked in choreonoid for HRP5P by the vrml repo of branch [mmurooka/ci-mimic](https://github.com/arntanguy/hrp5p/compare/topic/ci...mmurooka:topic/ci-mimic), which refers to this PR's revision for generate_robot_description submodule.

If there is no problem after checking with the real HRP5P, I think that hrp5_p_description can be completely migrated to auto-generated repo.