### PR TITLE
[update_repository.sh] Consider other branches automatically

### DIFF
--- a/update_repository.sh
+++ b/update_repository.sh
@@ -25,6 +25,19 @@ then
   exit 1
 fi
 
+cd $robot_dir
+branch=`git rev-parse --abbrev-ref HEAD`
+
+git ls-remote --exit-code --heads $remote_uri $branch > /dev/null
+
+if [ $? == "0" ]; then  # branch exists in remote_uri
+    pull_branch="$branch"
+fi
+
+if [ $branch != "master" ] && [ $branch != "main" ]; then
+    push_branch="$branch"
+fi
+
 echo "Cloning from ${remote_uri} (branch ${pull_branch}) to ${robot_desc_path}"
 # Clone robot_description repository
 git clone --recursive --single-branch --branch ${pull_branch} "${remote_uri}" ${robot_desc_path}

--- a/update_repository.sh
+++ b/update_repository.sh
@@ -68,5 +68,6 @@ Source commit: ${repo_uri}/commit/${ref_commit}
 Commit details:
 $ref_commit_msg"
 
+echo "Pushing into branch ${push_branch} of ${remote_uri}"
 git push -u origin ${push_branch}
 exit_if_error "Failed to push to remote robot_description repository ${robot_description_repository}"

--- a/update_repository.sh
+++ b/update_repository.sh
@@ -31,7 +31,7 @@ fi
 cd $robot_dir
 branch=`git rev-parse --abbrev-ref HEAD`
 
-git ls-remote --exit-code --heads $remote_uri $branch > /dev/null
+GIT_TRACE=1 GIT_TRACE_CURL=1 git ls-remote --exit-code --heads $remote_uri $branch > /dev/null
 
 if [ $? == "0" ]; then  # branch exists in remote_uri
     pull_branch="$branch"

--- a/update_repository.sh
+++ b/update_repository.sh
@@ -5,6 +5,9 @@
 ## latest generated model by the generate_robot_description.sh script
 ######################################################################
 
+# Add echo for every command that is executed
+set -x
+
 # Robot specific configuration (overrides the default configuration options above)
 . generate_config.sh
 


### PR DESCRIPTION
When creating a branch for a VRML robot model repository, it would be nice to have a corresponding branch in the description repository, in order to easily evaluate it.

Changed `update_repository.sh` with the following logic:

1)
- If the current branch in the VRML repository exists in the description repository (it was automatically generated before), we use that branch name to clone instead of the one written in `pull_branch`
- Otherwise (the branch was just created), we use the name written in `pull_branch` to clone

2)
- If the current branch in the VRML repository is `master` o `main`, we don't change the default `push_branch` as the convention for the main branch name might be different
- Otherwise, we use the same branch name as the current branch of the VRML repository to push
