### PR TITLE
Fix branch detection in github PR

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -36,8 +36,6 @@ export build_dir="$robot_dir/build"                     # path to the build dire
 # Gitlab: https://oauth2:${REPO_TOKEN}@gite.lirmm.fr/${robot_description_repository}
 export remote_uri="https://${maintainer_username}:${REPO_TOKEN}@github.com/${robot_description_repository}"
 export repo_uri="https://github.com/$robot_repository"
-export pull_branch="main"
-export push_branch="main"
 
 ## Robot-specific configuration (overrides the above variables)
 if [ -f $robot_dir/generate_config.sh ]


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/isri-aist/hrp2_drc_description/issues/1 : when pushing on a branch the CI would end-up pushing to the main branch of `hrp2_drc_description` instead of the corresponding branch name.

Upon investigation, it turns out that when running CI on a PR, the repository is in detached head state, thus making it impossible to determine which branch triggered the CI in the first place. In that case the `update_repository.sh` script would silently revert to using the default main branch.

The solution is to add a `GITHUB_BRANCH_NAME` environment variable in the CI script:

```yaml
    - name: Upload robot description
      shell: bash
      env:
        GITHUB_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
      run: |
        cd generate_robot_description
        ./update_repository.sh
```

This PR modifies the `update_repository.sh` to use the above variable if set, or try to determine which branch we are on when we are not in detached head state. In detached head state it explicitely fails early, thus preventing erroneous pushes.

Additionally, it is no longer necessary to specify a `push_branch` and a `pull_branch` configuration in the `generate_config.sh` script.