### PR TITLE
Upgrade CI to generate  models with ROS2

### DIFF
--- a/generate_config.sh
+++ b/generate_config.sh
@@ -23,21 +23,6 @@ export sample_points=2000                   # Number of points to sample on each
 export openhrp_export_collada_options=""     # Extra options for openhrp-export-collada (-a ...)
 export collada_urdf_options="-G -A"          # Extra options for collada_urdf
 
-## Generation paths 
-export tmp_path="/tmp/generate_${robot_desc_name}"      # tmp_path were the files are generated
-export gen_path="/tmp/${robot_desc_name}"               # path were the robot_description package gets generated
-export build_dir="$robot_dir/build"                     # path to the build directory
-
-## For CI
-# Ci will pull/push the robot description package to update it
-# You need the appropriate token in github secrets and your user-account.
-#
-# Github: https://${maintainer_username}:${REPO_TOKEN}@github.com/${robot_description_repository}
-# Gitlab: https://oauth2:${REPO_TOKEN}@gite.lirmm.fr/${robot_description_repository}
-export remote_uri="https://${maintainer_username}:${REPO_TOKEN}@github.com/${robot_description_repository}"
-export repo_uri="https://github.com/$robot_repository"
-export main_push_branch="" # Push to same branch name as the current main/master branch by default. If using older existing repositories, use "master" instead
-
 ## Robot-specific configuration (overrides the above variables)
 if [ -f $robot_dir/generate_config.sh ]
 then
@@ -46,3 +31,4 @@ then
 else
   echo "-- WARNING: no robot-specific configuration $robot_dir/generate_config.sh"
 fi
+. $this_dir/generate_final_config.sh

--- a/generate_final_config.sh
+++ b/generate_final_config.sh
@@ -1,0 +1,15 @@
+## Generation paths 
+tmp_dir="/tmp"
+export tmp_path="$tmp_dir/generate_${robot_desc_name}"      # tmp_path were the files are generated
+export gen_path="$tmp_dir/${robot_desc_name}"               # path were the robot_description package gets generated
+export build_dir="$robot_dir/build"                     # path to the build directory
+
+## For CI
+# Ci will pull/push the robot description package to update it
+# You need the appropriate token in github secrets and your user-account.
+#
+# Github: https://${maintainer_username}:${REPO_TOKEN}@github.com/${robot_description_repository}
+# Gitlab: https://oauth2:${REPO_TOKEN}@gite.lirmm.fr/${robot_description_repository}
+export remote_uri="https://${maintainer_username}:${REPO_TOKEN}@github.com/${robot_description_repository}"
+export repo_uri="https://github.com/$robot_repository"
+export main_push_branch="" # Push to same branch name as the current main/master branch by default. If using older existing repositories, use "master" instead

--- a/generate_robot_description.sh
+++ b/generate_robot_description.sh
@@ -73,14 +73,10 @@ function generate_convexes()
     mesh_name=`basename -- "$mesh"`
     mesh_name="${mesh_name%.*}"
     echo "-- Generating convex hull for ${mesh}"
-    mkdir -p ${tmp_path}/qc/${vrml_model_name}
-    mkdir -p ${gen_path}/convex/${vrml_model_name}
-    gen_cloud=${tmp_path}/qc/${vrml_model_name}/$mesh_name.qc
-    gen_convex=${gen_path}/convex/${vrml_model_name}/${mesh_name}-ch.txt
-    mesh_sampling ${mesh} ${gen_cloud} --type xyz --samples ${sample_points}
-    exit_if_error "Failed to sample pointcloud from mesh ${mesh} to ${gen_cloud}"
-    qconvex TI ${gen_cloud} TO ${gen_convex} Qt o f
-    exit_if_error "Failed to compute convex hull pointcloud from point cloud ${gen_cloud} to ${gen_convex}"
+    gen_convex_dir=${gen_path}/convex/${vrml_model_name}
+    mkdir -p ${gen_convex_dir}
+    mesh_sampling --in ${mesh} --convex ${gen_convex_dir} --type xyz --samples ${sample_points}
+    exit_if_error "Failed to compute convex hull pointcloud from point cloud ${gen_cloud} to ${gen_convex_dir}"
   done
 }
 

--- a/generate_robot_description.sh
+++ b/generate_robot_description.sh
@@ -49,7 +49,7 @@ function generate_urdf()
   gen_urdf_path=${gen_path}/urdf/${vrml_model_name}.urdf
   openhrp-export-collada -i ${gen_path}/vrml/${vrml_model} -o ${gen_collada_path} ${openhrp_export_collada_options}
   exit_if_error "Failed to convert VRML model to collada ($vrml_model})"
-  rosrun collada_urdf collada_to_urdf ${gen_collada_path} --output_file ${gen_urdf_path} --mesh_output_dir ${gen_path}/meshes/${vrml_model_name} --mesh_prefix "${urdf_mesh_prefix}/meshes/${vrml_model_name}" ${collada_urdf_options}
+  ros2 run collada_urdf collada_to_urdf ${gen_collada_path} --output_file ${gen_urdf_path} --mesh_output_dir ${gen_path}/meshes/${vrml_model_name} --mesh_prefix "${urdf_mesh_prefix}/meshes/${vrml_model_name}" ${collada_urdf_options}
   for f in `ls ${gen_path}/meshes/${vrml_model_name}/*.dae`
   do
     ./scripts/blender_remove_rotation.sh $f $f

--- a/scripts/add_mimic.py
+++ b/scripts/add_mimic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import yaml

--- a/update_repository.sh
+++ b/update_repository.sh
@@ -77,7 +77,15 @@ echo "==========================="
 echo "Cloning from ${remote_uri} (branch ${pull_branch}) to ${robot_desc_path}"
 # Clone robot_description repository
 git clone --recursive --single-branch --branch ${pull_branch} "${remote_uri}" ${robot_desc_path}
-exit_if_error "Failed to clone robot_description repository ${robot_description_repository}"
+if [ $? -ne 0 ]
+then
+  "Failed to clone robot_description repository ${robot_description_repository} from branch ${pull_branch}"
+  "Retry, assuming the branch does not exist and try to clone from main and then create the branch"
+  git clone --recursive --single-branch "${remote_uri}" ${robot_desc_path}
+  exit_if_error "Failed to clone robot_description repository ${robot_description_repository}"
+  cd ${robot_desc_path}
+  git checkout -b ${push_branch}
+fi
 
 # Synchronize files
 rsync -av --delete-after --exclude 'build' --exclude 'calib' --exclude '.git' --exclude '.github' $gen_path/ ${robot_desc_path}


### PR DESCRIPTION
This PR updates the generate_robot_description scripts to build with ROS2 on ubuntu jammy:
- Fix compilation of collada_to_urdf, see https://github.com/ros/collada_urdf/pull/49
- Adapt to mesh_sampling changes in https://github.com/jrl-umi3218/mesh_sampling/pull/4
- Add ability to generate rsdf files per-robot variant. To do so, create a folder named `rsdf/<robot variant name>` and add your rsdf files there. The behaviour is that all rsdf files in `rsdf/` are considered common to all variants and will be copied there, and files in `rsdf/<robot variant name>` are specific to that variant. If an rsdf file with the same name exists in both, the one of the variant prevails.
- Allow the robot_description repository not to have the branch and create a new branch based on main/master in that case.
- Fix generation of commit messages #6 